### PR TITLE
Update kernel-selftests to use fewer code paths

### DIFF
--- a/stats/kernel-selftests
+++ b/stats/kernel-selftests
@@ -1359,12 +1359,13 @@ class VmallocStater < Stater
     # [  223.187358] Summary: kvfree_rcu_2_arg_vmalloc_test passed: 1 failed: 0 repeat: 1 loops: 1000000 avg: 6333619 usec
     # [  223.198414] All test took worker0=441656368064 cycles
     when /Summary: (.+) passed: (.+) failed: (.+) repeat: (.+) loops: (.+) avg: (.+) usec/
-      if $3.to_i.positive?
-        @tmp_stats[$1] = 'fail'
-      elsif $2.to_i.positive?
+      result = 'fail'
+      if $3.to_i == 0
         @tmp_stats["#{$1}.usec_per_loop"] = $6.to_i
-        @tmp_stats[$1] = 'pass'
+        result = 'pass'
       end
+
+      @tmp_stats[$1] = result
     when /All test took (.+)=(.+) cycles/
       raise "unexpected summary: #{@test_prefix}.#{$1}" if @tmp_stats.empty?
 


### PR DESCRIPTION
This commit simplifies the VmallocStater class's
stat method by assuming that the vmalloc test failed until we know that the tests succeeded

To test, run the following:

rubocop stats/kernel-selftests
rake spec spec=stats

This commit targets issue: #264
